### PR TITLE
bug: Fixes multiple issues from first day

### DIFF
--- a/.emails/setup_email_two_day.Rmd
+++ b/.emails/setup_email_two_day.Rmd
@@ -31,12 +31,24 @@ We're looking forward to welcoming you to the RSE Sheffield training session on 
 
 ### SETUP
 
-Prior to attending, you need to **install the software we are going to use and create an account on GitHub. <span
-style="color: #d1410c;">Please ensure you have completed setup before the course begins.</span>**
+Prior to attending, you need to **install the software we are going to use and create and configure an account on
+GitHub.**
+
+#### <span style="color: #d1410c;">!!! Please ensure you have completed setup before the course begins !!!</span>
 
 Instructions on how to create the account as well as install all the software required can be found on the [**Setup
-Section**](https://fair2-for-research-software.github.io/git-collaboration/#setup) of the course materials. If you have
-any problems with your setup, please get in touch with us for assistance *before* the course begins.
+Section**](https://fair2-for-research-software.github.io/git-collaboration/#setup) of the course materials.
+
+Once complete you should be able to run `ssh -T git@github.com` and you will see a message similar to the following
+
+```
+ssh -T git@github.com
+Hi ns-rse! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+If you do not see this message you have a problem, most likely with the SSH key you generated and added to your account.
+If you have any problems with your setup, please get in touch with us for assistance _before_ the course begins and/or
+aim to turn up early so we can help you.
 
 
 ### SCHEDULE
@@ -52,7 +64,8 @@ There will be some time at the end of each day for questions and discussions.
 
 ### ATTENDANCE
 
-**In the event that you can no longer make it, we please ask that you cancel your ticket so we can offer it to someone on the waiting list**.
+**In the event that you can no longer make it, we please ask that you cancel your ticket so we can offer it to someone
+on the waiting list**.
 
 <!-- **NB** Please note we will _not_ be in the same venue on the second day. -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ po/*~
 # Emacs
 \#*
 *~
+.projectile-cache.eld

--- a/episodes/branching.md
+++ b/episodes/branching.md
@@ -78,7 +78,7 @@ You can change branches by using `git switch <branchname>`.
 We can improve the output of `git log` using the following options.
 
 ```bash
-git log --pretty="%h %ad (%cr) %x09 %an : %s"
+git log --graph --pretty="%h %ad (%cr) %x09 %an : %s"
 ```
 
 ::::::::::::::::::::::::::::::::::::: challenge
@@ -95,7 +95,7 @@ What are the commit hashes, commit messages, date/time and committers' names?
 
 ```bash
 git switch divide
-git log --pretty="%h %ad (%cr) %x09 %an : %s"
+git log --graph --pretty="%h %ad (%cr) %x09 %an : %s"
 * 6353fb4 - (HEAD -> divide, origin/divide) bug: Fix tpyo in divide function (2024-03-26 10:28:36 +0000) <Neil Shephard>
 * 7485e56 - chore: Fix merge conflict (2024-03-26 10:28:11 +0000) <Neil Shephard>
 * adfef4d - feat: Divide branch (2024-03-25 15:55:15 +0000) <Neil Shephard>
@@ -156,7 +156,7 @@ From the `git log` graph we see the first and last commits were:
 Again using the `python-maths` repository switch to the `multiply` branch. Use `git log` to find the commit at which
 `multiply` diverged from `main`. How many commits have been made on the `main` branch?
 
-**Hint** You will need to look at the log of the `main` branch.
+**Hint** You will need to find `HEAD -> multiply, origin/multiply` and follow the line backwards.
 
 :::::::::::::::::::::::: solution
 
@@ -166,66 +166,7 @@ Again using the `python-maths` repository switch to the `multiply` branch. Use `
 git switch main
 git log --graph --pretty="%h %ad (%cr) %x09 %an : %s"
 *   9a267a0 - (origin/main, origin/HEAD, main) Merge pull request #7 from slackline/ns-rse/6-square-root-warning (2025-02-10 14:22:58 +0000) <slackline>
-|\
-| * 784a268 - (origin/ns-rse/6-square-root-warning, ns-rse/6-square-root-warning) feature: add warning to square root if number is -ve (2025-02-10 14:18:34 +0$
-| * 0e3b6e0 - docs: Adding zero division example to docstring (2025-02-10 13:51:18 +0000) <Neil Shephard>
-* |   7ff8773 - Merge pull request #5 from slackline/ns-rse/zero-division-amend-fixup (2025-02-10 13:57:23 +0000) <slackline>
-|\ \
-| |/
-|/|
-| * 8165d09 - (origin/ns-rse/zero-division-amend-fixup) docs: Adding zero division example to docstring (2025-02-10 13:51:18 +0000) <Neil Shephard>
-* | b7625d6 - Merge pull request #4 from slackline/ns-rse/2-square-root (2025-02-10 13:15:42 +0000) <slackline>
-|\|
-| * 537c339 - (origin/ns-rse/2-square-root) feature: adds a square root function with tests (2025-02-10 12:55:21 +0000) <Neil Shephard>
-|/
-*   1e13f81 - Merge pull request #3 from slackline/ns-rse/zero-division (2025-02-10 12:27:53 +0000) <slackline>
-|\
-| * 0b8fd76 - (origin/ns-rse/zero-division) feature: Add exception and test for division by zero (2025-02-10 12:26:32 +0000) <Neil Shephard>
-|/
-*   f2de1f0 - Merge pull request #2 from slackline/ns-rse/add-contributing (2025-02-10 12:10:25 +0000) <slackline>
-|\
-| * 126b9de - (origin/ns-rse/add-contributing) doc: Adding CONTRIBUTING.md (2025-02-10 12:09:36 +0000) <Neil Shephard>
-|/
-* 80b95c0 - Link to course material (2025-02-10 11:03:03 +0000) <Neil Shephard>
-* efc6527 - Tpyo in title (2025-02-10 11:02:02 +0000) <Neil Shephard>
-*   105b37a - Merge pull request #13 from ns-rse/pre-commit-ci-update-config (2025-01-21 11:27:04 +0000) <Neil Shephard>
-|\
-| * a280884 - [pre-commit.ci] pre-commit autoupdate (2025-01-20 18:04:16 +0000) <pre-commit-ci[bot]>
-|/
-*   30c44b9 - Merge pull request #12 from ns-rse/pre-commit-ci-update-config (2024-12-10 10:28:29 +0000) <Neil Shephard>
-|\
-| * 20c0c4d - [pre-commit.ci] pre-commit autoupdate (2024-12-09 18:11:45 +0000) <pre-commit-ci[bot]>
-|/
-*   d49ed9a - Merge pull request #11 from ns-rse/pre-commit-ci-update-config (2024-09-24 10:08:00 +0100) <Neil Shephard>
-|\
-| * 9c35a18 - [pre-commit.ci] pre-commit autoupdate (2024-09-23 18:06:46 +0000) <pre-commit-ci[bot]>
-|/
-*   5c59a89 - Merge pull request #10 from ns-rse/pre-commit-ci-update-config (2024-09-06 12:24:55 +0100) <Neil Shephard>
-|\
-| * 88f1b11 - [pre-commit.ci] pre-commit autoupdate (2024-09-02 18:05:08 +0000) <pre-commit-ci[bot]>
-|/
-*   937f8a4 - Merge pull request #9 from ns-rse/ns-rse/correct-amend-fixup-templates (2024-05-23 16:54:28 +0100) <Neil Shephard>
-|\
-| * a84cb52 - bug: Simplify if statement in square root issue template (2024-05-23 16:52:46 +0100) <Neil Shephard>
-* |   557099b - Merge pull request #7 from ns-rse/pre-commit-ci-update-config (2024-05-23 16:53:46 +0100) <Neil Shephard>
-|\ \
-| * | 5cc9d6a - [pre-commit.ci] pre-commit autoupdate (2024-05-13 17:57:04 +0000) <pre-commit-ci[bot]>
-* | |   49a1dc6 - Merge pull request #8 from ns-rse/ns-rse/correct-amend-fixup-templates (2024-05-23 16:47:44 +0100) <Neil Shephard>
-|\ \ \
-| |/ /
-|/| /
-| |/
-| * 53e29fd - bug: Fix instructions for fixups (2024-05-23 16:45:53 +0100) <Neil Shephard>
-|/
-*   cdd8fcc - Merge pull request #6 from ns-rse/ns-rse/trail-run-fixes-2024-05-09 (2024-05-10 15:49:34 +0100) <Neil Shephard>
-|\
-| * fcf4ac2 - chore: Fixing errors identified in trial run (2024-05-09) (2024-05-10 11:04:36 +0100) <Neil Shephard>
-|/
-*   0a588bb - Merge pull request #5 from ns-rse/ns-rse/fix-template-04 (2024-05-09 15:38:44 +0100) <Neil Shephard>
-|\
-| * b2bb239 - Fixing name in issue 4 template (2024-05-09 15:38:05 +0100) <Neil Shephard>
-* | 9e22ef2 - Fixing name in issue 4 template (2024-05-09 15:37:12 +0100) <Neil Shephard>
-|/
+...
 * 3f6494f - chore: tidying up prior to trial run (2024-05-02 14:26:33 +0100) <Neil Shephard>
 * ba7a5da - bug: ISSUE_TEMPLATES > ISSUE_TEMPLATES (2024-04-24 14:49:45 +0100) <Neil Shephard>
 *   ae5402f - Merge pull request #3 from ns-rse/multiply (2024-04-23 23:14:14 +0100) <Neil Shephard>
@@ -265,11 +206,10 @@ git log --graph --pretty="%h %ad (%cr) %x09 %an : %s"
 ```
 
 This is a little more challenging to interpret but reading the output carefully we have an indicator of where the
-`origin/main` branch is where it reads `(origin/main, main)`. All subsequent commits are on the currently checked out
-branch which is `main` and `origin/multiply` (i.e. the local copy of the branch is at the same point as the remote
-on GitHub).
+`multiply` branch is where it reads `(HEAD -> multiply, origin/multiply)`. We can trace that line back to the furthest
+left branch (which is `main` and `origin/main`).
 
-Knowing this we can see that the `multiply` branch diverged from the `fa76751` commit on `main` and that three commits
+We can see that the `multiply` branch diverged from the `fa76751` commit on `main` and that three commits
 have been made on the `multiply` branch.
 
 :::::::::::::::::::::::::::::::::

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -8,6 +8,8 @@ exercises: 2
 
 - Who else is doing this course?
 - What can you expect from this course?
+- How do I use the command line?
+- How can I edit files at the command line?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -16,6 +18,8 @@ exercises: 2
 - Find out something interesting about other participants.
 - Understand the way in which you are expected to behave and interact with other participants.
 - Have an overview of the content and material that will be covered.
+- Basic command line navigation.
+- Basic use of `nano` editor.
 - Pair up with another participant to collaborate with during this workshop.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -140,6 +144,102 @@ The important part is that it points to the correct SSH key, in the above this i
 need modifying to reflect the users key for the account they wish to use.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+## Bash and Nano Basics
+
+You will be using the [Bash][bash] shell to navigate and type commands and the [nano][nano] editor to edit files,
+although you are free to edit your files in any programme you want such as VSCode, RStudio or Emacs.
+
+### Bash
+
+There are a few useful tips and tricks you can use to help you work at the command line more quickly.
+
+#### Navigation
+
+You can find out what directory you are in using `pwd` (`p`resent `w`orking `d`irectory).
+
+```bash
+pwd
+/home/neil/work/git
+```
+
+You can use `cd` to (`c`hange `d`irectory).
+
+**NB** The tilde (`~`) is short cut for your "home" directory, typically `/home/<username>` on GNU/Linux systems,
+`/Users/<username>` on OSX and `/c/Users/<username>` on Window systems.
+
+``` bash
+cd ~/work
+```
+
+You can create directories with `mkdir` (`m`a`k`e `dir`ectory), the `-p` flag ensures the parent directories exist.
+
+``` bash
+mkdir ~/work/git
+```
+
+#### Tab Completion
+
+You can start typing a command or directory path in Bash and use the `<Tab>` button to auto-complete the word you are
+typing. If you have typed sufficient characters to give a unique command or path Bash will complete it for you. If there
+are several options you will be presented with a list of the options, one of which will be highlighted. Hitting `<Tab>`
+again will move onto the next possible completion. When you are at the completion you want simply hit `<Return>` and it
+will be entered on your command line.
+
+```bash
+cd ~/te <Tab>
+tests/  tmp/
+```
+
+#### History
+
+Bash keeps a record of the commands you use in its `history`. You can view _all_ your history by simply typing
+`history`.
+
+```bash
+history
+
+cd work
+mkdir git
+git clone git@github.com:ns-rse/python-maths
+```
+
+### Nano
+
+[Nano][nano] is a basic terminal editor, you open files by calling `nano <path/to/filename>`, there is a useful [nano
+cheatsheet][nano_cheat].
+
+#### Navigating
+
+You can jump to a specific line number with `Ctrl + /` and will be prompted for the line you want to go to, on hitting
+`Return` the cursor will move there.
+
+#### Finding text
+
+If you want to search for some text you can do so with `Ctrl + F` and you are prompted to enter some text, on hitting
+`Return` the cursor moves to the next instance of that text (if it is present!). If you hit `Ctrl + F` again you can
+either enter new text to search for or you can hit `Return` to search for the previous text again.
+
+#### Saving Files
+
+When you are done editing use `Ctrl + O` to save the file you are editing, you are prompted for a file to save it to,
+typically you don't need to change this, just hit `Enter`.
+
+#### Exiting `nano`
+
+When done editing you need to exit and return to the command line, you do this with `Ctrl + x`.
+
+#### Useful alias
+
+You may want to set the following alias in your `~/.bashrc` file, it sets various options. You can then `source
+~/.bashrc` to
+
+```bash
+echo "alias nano='nano --autoindent --linenumbers --tabstospaces --tabsize=4'" >> ~/.bashrc
+
+```
+
+These options will be used whenever you use `nano`. See more options with `nano --help`
 
 ## Cloning Repositories
 
@@ -418,6 +518,7 @@ create a pull request and merge the changes.
 the most well known but there are many others including [BitBucket][bitbucket], [Codeberg][codeberg], and
 [ForgeJo][forgejo] and [SourceHut][sourcehut].
 
+[bash]: https://www.gnu.org/software/bash/
 [bitbucket]: https://bitbucket.org/
 [coc]: https://rse.shef.ac.uk/community/code_of_conduct
 [codeberg]: https://codeberg.org/
@@ -429,6 +530,8 @@ the most well known but there are many others including [BitBucket][bitbucket], 
 [gl]: https://gitlab.com
 [linux]: https://www.kernel.org
 [linuxGithub]: https://github.com/torvalds/linux
+[nano]: https://www.nano-editor.org/
+[nano_cheat]: https://www.nano-editor.org/dist/latest/cheatsheet.html
 [openTracks]: https://github.com/OpenTracksApp/OpenTracks
 [pairprogramming]: https://en.wikipedia.org/wiki/Pair_programming
 [pypi]: https://pypi.org/

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,24 +2,24 @@
 title: Setup
 ---
 
-## Setup
+## Git
 
 There are many Git clients (porcelains) out there and many Integrated Development Environments (IDEs) support Git
 actions and facilitate using the bewildering array of options, but this course teaches the Command Line Interface (CLI)
 to Git as it means we have a consistent interface to teach the _principles_ that you can take away to your own choice of
 Git client. Below there are instructions for installing Git on each of the three most common operating systems.
 
-Please complete these setup tasks _before_ attending the course. If you have any issues getting setup please either
+Please complete these setup tasks **before** attending the course. If you have any issues getting setup please either
 contact an instructor in advance or arrive early and seek assistance from an instructor.
 
-## Example Repository
+<!-- ## Example Repository -->
 
-This course uses a GitHub Template that you will, in small groups, create a copy of and collaborate on. Using this
-template and setting it up is part of the course, you do not need to set it up in advance.
-
-## Install Git
+<!-- This course uses a GitHub Template that you will, in small groups, create a copy of and collaborate on. Using this -->
+<!-- template and setting it up is part of the course, you do not need to set it up in advance. -->
 
 ::::::::::::::::::::::::::::::::::::::: discussion
+
+## Install Git
 
 As this is a course about using [Git][git] you will need to have it installed on your computer. If you're already using
 Git then the chances are high you already have it installed or it may be integrated into your Integrated Development
@@ -78,76 +78,74 @@ your distribution. This will vary between distributions but some common ones are
 #### Arch
 
 ``` bash
-pacman -Syu git
+sudo pacman -Syu git
 ```
 
 #### Debian/Ubuntu
 
 ``` bash
-apt-get install git
+sudo apt-get install git
 ```
 
 #### Fedora
 
 ``` bash
-dnf install git
+sudo dnf install git
 ```
 
 #### Gentoo
 
 ``` bash
-emerge -av dev-vcs/git
+sudo emerge -av dev-vcs/git
 ```
 
 :::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::::: callout
-
-## Windows SSH Agent
-
-If you are using Windows you may want to enable the [ssh-agent][win_ssh_agent].
-
-::::::::::::::::::::::::::::::::::::::::::::::::
-
 ## GitHub
-
-::::::::::::::::::::::::::::::::::::::: discussion
 
 You will also need an account on [GitHub][gh]. If you do not already have one please
 [register](https://github.com/signup), if you have an academic email address such as `@<institute>.ac.uk` or
 `@<institute.edu>` then registering with this address will give you access to a few more features.
 
-You should generate an SSH keys _using a secure password when creating them_, then add the public component to your
-[GitHub account][github_ssh].
+## SSH Keys
+
+::::::::::::::::::::::::::::::::::::::: discussion
+
+## ESSENTIAL
+
+You **MUST** generate an SSH key _using a secure password_, then add the public component to your [GitHub
+account][github_ssh].
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::: solution
 
-### Windows
+### Generate SSH Keys
 
-There are [comprehensive instructions][putty-ssh] on using the Windows SSH client [PuTTY][putty] to generate SSH keys.
+There is a detailed [article][ssh-keygen] on creating SSH keys under Linux and OSX that works with Git Bash too. It is
+recommended to use the newer [ed25519][ssh-ed25519] algorithm. In a terminal or Git Bash shell, you can do this using
+the following commands.
 
-:::::::::::::::::::::::::
-
-:::::::::::::::: solution
-
-### Linux / OSX
-
-There is a detailed [article][ssh-keygen] on creating SSH keys under Linux and OSX. It is recommended to use the newer
-[ed25519][ssh-ed25519] algorithm. In a terminal you can do this using the following commands.
-
-``` bash
+```bash
 ssh-keygen -a 100 -t ed25519
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/home/neil/.ssh/id_ed25519):
+Enter passphrase for "id_ed25519" (empty for no passphrase):
+Enter same passphrase again:
 ```
 
-This creates two files in the `~/.ssh/` directory, the private key (`~/.ssh/id_ed25519'`) and the public key
+As shown above, you will need to confirm the location that the SSH keys will be saved to (hit enter to select the
+default which will be `~/.ssh/id_ed25519`) and _then_ enter a secure passphrase (you will be asked to enter it twice to
+confirm you know what it is, do not forget it!).
+
+This creates two files in the `~/.ssh/` directory by default, the private key (`~/.ssh/id_ed25519'`) and the public key
 (`~/.ssh/id_ed25519.pub`). These are text files and it is the contents of the later that you need to add to GitHub (see
 next solution). You can view the contents of the `~/.ssh/id_ed25519.pub` file that you need to copy to your GitHub
 account with.
 
-``` bash
+```bash
 cat ~/.ssh/id_ed25519.pub
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIARcKip5cMGhQvOooF0sAFTvLAj8R7wz+7cPV9BndPtL neil@haldane
 ```
 
 :::::::::::::::::::::::::
@@ -160,6 +158,20 @@ Once you have created your SSH key you need to copy it to your account, got to _
 on the _New SSH key_ button. Enter a name for your key, set the **Key type** to _Authenticaion Key_ and paste your
 public key (the contents of the file ending in `.pub`) into the **Key** box then click the _Add SSH key_ button.
 
+:::::::::::::::::::::::::
+
+:::::::::::::::: solution
+
+### Checking your key works
+
+You can test if you have setup your SSH key by running the following command which should produce similar output.
+
+```bash
+ssh -T git@github.com
+Hi ns-rse! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+If you do **not** see the above successful authentication message please get in touch **before** the course starts.
 :::::::::::::::::::::::::
 
 ## Conda Environments
@@ -211,8 +223,8 @@ You will have to create a virtual environment to undertake the course. If you ha
 above you open a terminal (Windows use the Git Bash Shell) and create a Virtual Environment called `git-collaboation`.
 
 ``` bash
-conda create --name git-collaboration python=3.11
-conda activate git-collaboration
+conda create --name git-collab python=3.11
+conda activate git-collab
 ```
 
 :::::::::::::::::::::::::
@@ -227,10 +239,7 @@ conda activate git-collaboration
 [miniconda3]: https://docs.anaconda.com/free/miniconda/
 [miniforge3]: https://conda-forge.org/
 [miniforge3-install]: https://github.com/conda-forge/miniforge
-[putty]: https://www.ssh.com/ssh/putty/download
-[putty-ssh]: https://www.ssh.com/academy/ssh/putty/windows/puttygen#creating-a-new-key-pair-for-authentication
 [python]: https://python.org
 [ssh-ed25519]: https://blog.g3rt.nl/upgrade-your-ssh-keys.html
 [ssh-keygen]: https://www.digitalocean.com/community/tutorials/how-to-create-ssh-keys-with-openssh-on-macos-or-linux
 [virtualenvwrapper]: https://rse.shef.ac.uk/blog/2024-08-13-python-virtualenvwrapper/
-[win_ssh_agent]: https://peateasea.de/starting-ssh-agent-in-windows-powershell/


### PR DESCRIPTION
- Ignore Emacs projectile file.
- Improve setup email to emphasise need to complete all steps and how to test SSH keys are in place.
- Ensures `--graph` option is included in the `git log --pretty` example from the start.
- Adds a hint to second `git log` challenge and removes unnecessary output.
- Very brief introduction to navigating in Bash and using Nano to edit files added to introduction.
- Improve setup instructions...
  - Remove mention of PuTTy for SSH keys, can all be done from Git Bash.
  - How to test SSH keys are correctly setup.